### PR TITLE
Remove link to fonts.css

### DIFF
--- a/index-template.html
+++ b/index-template.html
@@ -8,7 +8,6 @@
 
 		<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-                <link href="css/fonts.css" rel="stylesheet">
 		<link href="css/bootstrap.css" rel="stylesheet">
 		<link href="css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="css/custom.css" rel="stylesheet">

--- a/index-test.html
+++ b/index-test.html
@@ -8,7 +8,6 @@
 
     <!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <link href="css/fonts.css" rel="stylesheet">
 		                              <link href="css/bootstrap.css" rel="stylesheet">
 		                              <link href="css/bootstrap-responsive.css" rel="stylesheet">
 		                              <link href="css/custom.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
 
 		<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-                <link href="css/fonts.css" rel="stylesheet">
 		<link href="css/bootstrap.css" rel="stylesheet">
 		<link href="css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="css/custom.css" rel="stylesheet">

--- a/src/conf/berlin2014.html
+++ b/src/conf/berlin2014.html
@@ -8,7 +8,6 @@
 
 		<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-                <link href="../css/fonts.css" rel="stylesheet">
 		<link href="../css/bootstrap.css" rel="stylesheet">
 		<link href="../css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="../css/custom.css" rel="stylesheet">

--- a/src/conf/index.html
+++ b/src/conf/index.html
@@ -8,7 +8,6 @@
 
 		<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-                <link href="../css/fonts.css" rel="stylesheet">
 		<link href="../css/bootstrap.css" rel="stylesheet">
 		<link href="../css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="../css/custom.css" rel="stylesheet">

--- a/src/conf/london201411.html
+++ b/src/conf/london201411.html
@@ -8,7 +8,6 @@
 
 		<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-                <link href="../css/fonts.css" rel="stylesheet">
 		<link href="../css/bootstrap.css" rel="stylesheet">
 		<link href="../css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="../css/custom.css" rel="stylesheet">

--- a/src/pendingpoints.html
+++ b/src/pendingpoints.html
@@ -8,7 +8,6 @@
 
 		<!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-                <link href="css/fonts.css" rel="stylesheet">
 		<link href="css/bootstrap.css" rel="stylesheet">
 		<link href="css/bootstrap-responsive.css" rel="stylesheet">
 		<link href="css/custom.css" rel="stylesheet">

--- a/templates/index.html.mustache
+++ b/templates/index.html.mustache
@@ -8,7 +8,6 @@
 
     <!--[if lt IE 9]><script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
 
-    <link href="css/fonts.css" rel="stylesheet">
 		                              <link href="css/bootstrap.css" rel="stylesheet">
 		                              <link href="css/bootstrap-responsive.css" rel="stylesheet">
 		                              <link href="css/custom.css" rel="stylesheet">


### PR DESCRIPTION
It's now included in custom.css (less import statement). This avoid a 404 error on every page load (https://tosdr.org/css/fonts.css)
