### PR TITLE
 reference either Service or Service-Point through GET (not hash) parameters

### DIFF
--- a/src/js/tosdr.js
+++ b/src/js/tosdr.js
@@ -79,7 +79,6 @@ $(function () {
 
   if (location.hash.length > 1) {
     var hash = location.hash.substring(1);
-
     if (hash.indexOf("=") != -1) {
       var splits = hash.split("=");
       if (splits.length == 2 && splits[0] == "search" && splits[1].length > 0) {
@@ -90,6 +89,25 @@ $(function () {
         $('html, body').animate({
           scrollTop: $("#services").offset().top
         }, 1000);
+      } else if (splits.length == 2 && splits[0] == "servicePoint" && splits[1].length > 0) {
+        
+        // allows for directly referencing a service's point in URL
+          // ex.: https://tosdr.org/#servicePoint=google__lU-QhFXMOcU 
+          // hash syntax: /#servicePoint=<serviceName>__<pointId>
+          
+        if (splits[1].indexOf('__') != -1 && splits[1].split('__')[0].length > 0 && 
+            splits[1].split('__')[1].length > 0 ) {
+          var serviceName = splits[1].split('__')[0];
+          var pointId = splits[1].split('__')[1];
+          var serviceMatchBool = showModal(serviceName)
+          if (serviceMatchBool){
+            var subtractFromOffset = $(".modal-header").outerHeight() + $("#modal_" + serviceName).offset().top + 5
+            var offset = $("#popup-point-" + serviceName + "-" + pointId).offset().top
+            $('#modal_' + serviceName + ' .modal-body').animate({
+              scrollTop: offset - subtractFromOffset
+            }, 1000)
+          } 
+        }
       }
     } else {
       showModal(hash);

--- a/src/js/tosdr.js
+++ b/src/js/tosdr.js
@@ -89,29 +89,38 @@ $(function () {
         $('html, body').animate({
           scrollTop: $("#services").offset().top
         }, 1000);
-      } else if (splits.length == 2 && splits[0] == "servicePoint" && splits[1].length > 0) {
-        
-        // allows for directly referencing a service's point in URL
-          // ex.: https://tosdr.org/#servicePoint=google__lU-QhFXMOcU 
-          // hash syntax: /#servicePoint=<serviceName>__<pointId>
-          
-        if (splits[1].indexOf('__') != -1 && splits[1].split('__')[0].length > 0 && 
-            splits[1].split('__')[1].length > 0 ) {
-          var serviceName = splits[1].split('__')[0];
-          var pointId = splits[1].split('__')[1];
-          var serviceMatchBool = showModal(serviceName)
-          if (serviceMatchBool){
-            var subtractFromOffset = $(".modal-header").outerHeight() + $("#modal_" + serviceName).offset().top + 5
-            var offset = $("#popup-point-" + serviceName + "-" + pointId).offset().top
-            $('#modal_' + serviceName + ' .modal-body').animate({
-              scrollTop: offset - subtractFromOffset
-            }, 1000)
-          } 
-        }
-      }
+      } 
     } else {
       showModal(hash);
     }
   }
+  
+  if (location.search.indexOf('?') == 0) {
+    var GETarguments = location.search.substring(1)
+    var splits = GETarguments.split("=");
+    if (splits.length == 2 && splits[0] == "servicePoint" && splits[1].length > 0) {
+      
+      // allows for directly referencing a service's point in URL
+        // ex.: https://tosdr.org/?servicePoint=google__lU-QhFXMOcU 
+        // GET parameters syntax: /?servicePoint=<serviceName>__<pointId>
+        
+      if (splits[1].indexOf('__') != -1 && splits[1].split('__')[0].length > 0 && 
+          splits[1].split('__')[1].length > 0 ) {
+        var serviceName = splits[1].split('__')[0];
+        var pointId = splits[1].split('__')[1];
+        var serviceMatchBool = showModal(serviceName);
+        if (serviceMatchBool){
+          var subtractFromOffset = $(".modal-header").outerHeight() + $("#modal_" + serviceName).offset().top + 5
+          var offset = $("#popup-point-" + serviceName + "-" + pointId).offset().top;
+          $('#modal_' + serviceName + ' .modal-body').animate({
+            scrollTop: offset - subtractFromOffset
+          }, 1000)
+        }
+      } 
+    } else {  // also add GET parameter support for basic service referencing
+      showModal(GETarguments);
+    }
+  }
+  
 });
 


### PR DESCRIPTION
- because Facebook and Google+ lose #{{fragments}} in share dialogs
- urls with GET arguments are more resilient/permanent/shareable