### PR TITLE
Github doesn't require legal name

### DIFF
--- a/src/points/legal-name-registration.json
+++ b/src/points/legal-name-registration.json
@@ -10,8 +10,7 @@
     "spec-version": "1.1"
   },
   "services": [
-    "yahoo",
-    "github"
+    "yahoo"
   ],
   "title": "You must provide your legal name upon registration",
   "topics": [


### PR DESCRIPTION
Github was never **required** a legal name to sign up.  While they do have a profile field for this, it is and always has been optional.  Their ToS does say:

> You must provide your name, a valid email address, and any other information requested in order to complete the signup process.

However, they only ask for a username during the signup process.  Since this bullet point doesn't specify "legal name", it is probably safe to assume that it applies to the "username" which they do require.

I am, of course, not a lawyer so I cannot speak to the legally binding aspects at play here.  However, I am a github employee that has fielded a large number of support requests about our terms in the past, and feel that I can confidently say that github does not care about your legal name.  I say this having worked for the company for many years under a pseudonym, my legal name known only to a handful that must have it (like payroll and HR).