### PR TITLE
Link to crawls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,8 @@ module.exports = function (grunt) {
   // Configurable paths for the application
   var appConfig = {
     src: 'src', // TODO When implementing bower, change to: require('./bower.json').srcPath || 'src'
-    dist: 'dist'
+    dist: 'dist',
+    crawls: '../tosback2/crawl/'
   };
   
   grunt.initConfig({

--- a/build/fixservices.js
+++ b/build/fixservices.js
@@ -23,12 +23,10 @@ function doFile(filepath, filename, grunt) {
   var obj = grunt.file.readJSON(filepath),
       changed = false;
 
-  if(typeof(obj.id) != 'string') {
-    grunt.log.error('id wrong (' + filename + ')');
-    if(!obj.id) {
-      obj.id = filename.substring(0, filename.length-5);
-      changed = true;
-   }
+  if(typeof(obj.slug) != 'string') {
+    grunt.log.error('slug wrong (' + filename + ')');
+    obj.slug = filename.substring(0, filename.length-5);
+    changed = true;
   }
   if(typeof(obj.name) != 'string') {
     grunt.log.error('name wrong (' + filename + ')');
@@ -58,24 +56,25 @@ function doFile(filepath, filename, grunt) {
     delete obj.url
     changed = true
   }
-  let crawls = []
+
   if (!Array.isArray(obj.crawls)) {
     obj.crawls = []
     changed = true
   }
   for (let i=0; i< obj.urls.length; i++) {
     const crawlsPath = grunt.config.get('conf').crawls + obj.urls[i]
-    console.log(filepath, crawlsPath)
+    console.log(filepath, obj.urls[i], crawlsPath)
     if (grunt.file.exists(crawlsPath)) {
       grunt.file.recurse(crawlsPath, (absPath, rootDir, subDir, filename) => {
-        obj.crawls.push(subDir + filename)
+        const thisPath = obj.urls[i] /* Referring to loop iterator, but this callback function has lexical scope! */ + '/' + filename
+        if (obj.crawls.indexOf(thisPath) === -1) {
+          obj.crawls.push(thisPath)
+          changed = true
+        }
       })
     }
   }
-  if (JSON.stringify(obj.crawls) != JSON.stringify(crawls)) {
-    obj.crawls = crawls
-    changed = true
-  }
+
   if(typeof(obj.fulltos) != 'object' || Array.isArray(obj.fulltos)) {
     grunt.log.error('fulltos wrong (' + filename + ')');
     if(!obj.fulltos) {

--- a/build/fixservices.js
+++ b/build/fixservices.js
@@ -22,7 +22,7 @@ module.exports = function(grunt){
 function doFile(filepath, filename, grunt) {
   var obj = grunt.file.readJSON(filepath),
       changed = false;
-  
+
   if(typeof(obj.id) != 'string') {
     grunt.log.error('id wrong (' + filename + ')');
     if(!obj.id) {
@@ -56,6 +56,24 @@ function doFile(filepath, filename, grunt) {
   }
   if (obj.url) {
     delete obj.url
+    changed = true
+  }
+  let crawls = []
+  if (!Array.isArray(obj.crawls)) {
+    obj.crawls = []
+    changed = true
+  }
+  for (let i=0; i< obj.urls.length; i++) {
+    const crawlsPath = grunt.config.get('conf').crawls + obj.urls[i]
+    console.log(filepath, crawlsPath)
+    if (grunt.file.exists(crawlsPath)) {
+      grunt.file.recurse(crawlsPath, (absPath, rootDir, subDir, filename) => {
+        obj.crawls.push(subDir + filename)
+      })
+    }
+  }
+  if (JSON.stringify(obj.crawls) != JSON.stringify(crawls)) {
+    obj.crawls = crawls
     changed = true
   }
   if(typeof(obj.fulltos) != 'object' || Array.isArray(obj.fulltos)) {

--- a/src/services/4lnb.json
+++ b/src/services/4lnb.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 474,

--- a/src/services/500px.json
+++ b/src/services/500px.json
@@ -1,6 +1,9 @@
 {
   "alexa": 2183,
-  "crawls": [],
+  "crawls": [
+    "500px.com/Privacy Policy.txt",
+    "500px.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 282,

--- a/src/services/500px.json
+++ b/src/services/500px.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2183,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 282,

--- a/src/services/abc-australia.json
+++ b/src/services/abc-australia.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 436,

--- a/src/services/accuweather.json
+++ b/src/services/accuweather.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 456,

--- a/src/services/adobe.json
+++ b/src/services/adobe.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 417,

--- a/src/services/airbnb.json
+++ b/src/services/airbnb.json
@@ -1,5 +1,6 @@
 {
   "alexa": 356,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/airbnb.json
+++ b/src/services/airbnb.json
@@ -1,6 +1,12 @@
 {
   "alexa": 356,
-  "crawls": [],
+  "crawls": [
+    "airbnb.com/Copyright Policy.txt",
+    "airbnb.com/Guest Refund Policy Terms.txt",
+    "airbnb.com/Host Guarantee Terms and Conditions.txt",
+    "airbnb.com/Privacy Policy.txt",
+    "airbnb.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/albine.json
+++ b/src/services/albine.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 486,

--- a/src/services/allrecipe.json
+++ b/src/services/allrecipe.json
@@ -1,4 +1,5 @@
 {
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 176,

--- a/src/services/allrecipes.json
+++ b/src/services/allrecipes.json
@@ -1,5 +1,6 @@
 {
   "alexa": 639,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 187,

--- a/src/services/allrecipes.json
+++ b/src/services/allrecipes.json
@@ -1,6 +1,8 @@
 {
   "alexa": 639,
-  "crawls": [],
+  "crawls": [
+    "allrecipes.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 187,

--- a/src/services/amazon.json
+++ b/src/services/amazon.json
@@ -1,5 +1,6 @@
 {
   "alexa": 10,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 190,

--- a/src/services/amazon.json
+++ b/src/services/amazon.json
@@ -1,6 +1,19 @@
 {
   "alexa": 10,
-  "crawls": [],
+  "crawls": [
+    "amazon.com/AMAZON SILK TERMS & CONDITIONS.txt",
+    "amazon.com/Amazon App Suite Legal Notices.txt",
+    "amazon.com/Amazon Kindle Store Terms of Use.txt",
+    "amazon.com/Amazon.com Privacy Notice.txt",
+    "amazon.com/Conditions of Use.txt",
+    "amazon.com/Interest-Based Ads.txt",
+    "amazon.com/Kindle Cloud Reader Legal Notices.txt",
+    "amazon.com/Kindle for Android Legal Notices.txt",
+    "amazon.com/Kindle for Mac Legal Notices.txt",
+    "amazon.com/Kindle for PC Legal Notices.txt",
+    "amazon.com/Kindle for Windows 8 Legal Notices.txt",
+    "amazon.com/Third Party Licenses.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 190,

--- a/src/services/ancestry.json
+++ b/src/services/ancestry.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 452,

--- a/src/services/app-net.json
+++ b/src/services/app-net.json
@@ -1,6 +1,9 @@
 {
   "alexa": 1000000,
-  "crawls": [],
+  "crawls": [
+    "app.net/Privacy Policy.txt",
+    "app.net/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 337,

--- a/src/services/app-net.json
+++ b/src/services/app-net.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 337,

--- a/src/services/apple-icloud.json
+++ b/src/services/apple-icloud.json
@@ -1,5 +1,6 @@
 {
   "alexa": 373,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 304,

--- a/src/services/apple.json
+++ b/src/services/apple.json
@@ -1,6 +1,11 @@
 {
   "alexa": 61,
-  "crawls": [],
+  "crawls": [
+    "apple.com/Privacy Policy.txt",
+    "apple.com/Website Terms of Service.txt",
+    "apple.com/iCloud Terms of Service.txt",
+    "apple.com/iTunes Terms of Service.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/apple.json
+++ b/src/services/apple.json
@@ -1,5 +1,6 @@
 {
   "alexa": 61,
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/applits.json
+++ b/src/services/applits.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 400,

--- a/src/services/applyyourself.json
+++ b/src/services/applyyourself.json
@@ -1,5 +1,6 @@
 {
   "alexa": 4884,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 423,

--- a/src/services/arc-games.json
+++ b/src/services/arc-games.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 349,

--- a/src/services/ask.json
+++ b/src/services/ask.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 370,

--- a/src/services/at-t.json
+++ b/src/services/at-t.json
@@ -1,5 +1,6 @@
 {
   "alexa": 581,
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/at-t.json
+++ b/src/services/at-t.json
@@ -1,6 +1,12 @@
 {
   "alexa": 581,
-  "crawls": [],
+  "crawls": [
+    "att.com/Acceptable Use Policy.txt",
+    "att.com/Internet Terms of Service.txt",
+    "att.com/Privacy Policy.txt",
+    "att.com/Terms of Service.txt",
+    "att.com/Wireless Plan Terms.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/audiotool.json
+++ b/src/services/audiotool.json
@@ -1,5 +1,6 @@
 {
   "alexa": 52018,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 260,

--- a/src/services/ba.com.json
+++ b/src/services/ba.com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 25322,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 220,

--- a/src/services/badoo.json
+++ b/src/services/badoo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 364,

--- a/src/services/bbc.json
+++ b/src/services/bbc.json
@@ -1,5 +1,6 @@
 {
   "alexa": 104,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 322,

--- a/src/services/bearshare.json
+++ b/src/services/bearshare.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/bewelcome.json
+++ b/src/services/bewelcome.json
@@ -1,5 +1,6 @@
 {
   "alexa": 349156,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 299,

--- a/src/services/billionsinchange.json
+++ b/src/services/billionsinchange.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 372,

--- a/src/services/bing.json
+++ b/src/services/bing.json
@@ -1,5 +1,6 @@
 {
   "alexa": 44,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 331,

--- a/src/services/bing.json
+++ b/src/services/bing.json
@@ -1,6 +1,8 @@
 {
   "alexa": 44,
-  "crawls": [],
+  "crawls": [
+    "bing.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 331,

--- a/src/services/bit-ly.json
+++ b/src/services/bit-ly.json
@@ -1,5 +1,6 @@
 {
   "alexa": 982,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/bitbucket.json
+++ b/src/services/bitbucket.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1094,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 293,

--- a/src/services/bitcasa.json
+++ b/src/services/bitcasa.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 340,

--- a/src/services/bitcasa.json
+++ b/src/services/bitcasa.json
@@ -1,6 +1,10 @@
 {
   "alexa": 1000000,
-  "crawls": [],
+  "crawls": [
+    "bitcasa.com/Acceptable Use Policy.txt",
+    "bitcasa.com/Privacy Policy.txt",
+    "bitcasa.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 340,

--- a/src/services/bitpay.json
+++ b/src/services/bitpay.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 470,

--- a/src/services/bittorrent.json
+++ b/src/services/bittorrent.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 374,

--- a/src/services/bittorrentsync.json
+++ b/src/services/bittorrentsync.json
@@ -1,4 +1,5 @@
 {
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 238,

--- a/src/services/blogger.json
+++ b/src/services/blogger.json
@@ -1,5 +1,6 @@
 {
   "alexa": 157,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 494,

--- a/src/services/blogger.json
+++ b/src/services/blogger.json
@@ -1,6 +1,9 @@
 {
   "alexa": 157,
-  "crawls": [],
+  "crawls": [
+    "blogger.com/Privacy Policy.txt",
+    "blogger.com/Terms Of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 494,

--- a/src/services/blogspot.json
+++ b/src/services/blogspot.json
@@ -1,6 +1,9 @@
 {
   "alexa": 70,
-  "crawls": [],
+  "crawls": [
+    "blogspot.com/Privacy Policy.txt",
+    "blogspot.com/Terms Of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 326,

--- a/src/services/blogspot.json
+++ b/src/services/blogspot.json
@@ -1,5 +1,6 @@
 {
   "alexa": 70,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 326,

--- a/src/services/bluestacks.json
+++ b/src/services/bluestacks.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 447,

--- a/src/services/bodybuilding.json
+++ b/src/services/bodybuilding.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 471,

--- a/src/services/boingo.json
+++ b/src/services/boingo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 96972,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 263,

--- a/src/services/burning-man.json
+++ b/src/services/burning-man.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 476,

--- a/src/services/bushel.json
+++ b/src/services/bushel.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 480,

--- a/src/services/cafemom.json
+++ b/src/services/cafemom.json
@@ -1,5 +1,6 @@
 {
   "alexa": 7748,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/canary.json
+++ b/src/services/canary.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 454,

--- a/src/services/careerone.json
+++ b/src/services/careerone.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 396,

--- a/src/services/caringbridge.json
+++ b/src/services/caringbridge.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 365,

--- a/src/services/centurylink.json
+++ b/src/services/centurylink.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 389,

--- a/src/services/chromewebstore.json
+++ b/src/services/chromewebstore.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 385,

--- a/src/services/cloudant.json
+++ b/src/services/cloudant.json
@@ -1,5 +1,6 @@
 {
   "alexa": 353676,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 272,

--- a/src/services/cloudant.json
+++ b/src/services/cloudant.json
@@ -1,6 +1,9 @@
 {
   "alexa": 353676,
-  "crawls": [],
+  "crawls": [
+    "cloudant.com/Privacy.txt",
+    "cloudant.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 272,

--- a/src/services/cnet.json
+++ b/src/services/cnet.json
@@ -1,6 +1,8 @@
 {
   "alexa": 153,
-  "crawls": [],
+  "crawls": [
+    "cnet.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 316,

--- a/src/services/cnet.json
+++ b/src/services/cnet.json
@@ -1,5 +1,6 @@
 {
   "alexa": 153,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 316,

--- a/src/services/cnn.json
+++ b/src/services/cnn.json
@@ -1,6 +1,8 @@
 {
   "alexa": 108,
-  "crawls": [],
+  "crawls": [
+    "cnn.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 318,

--- a/src/services/cnn.json
+++ b/src/services/cnn.json
@@ -1,5 +1,6 @@
 {
   "alexa": 108,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 318,

--- a/src/services/codeschool.json
+++ b/src/services/codeschool.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 485,

--- a/src/services/coinbase.json
+++ b/src/services/coinbase.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 407,

--- a/src/services/colloq-io.json
+++ b/src/services/colloq-io.json
@@ -1,4 +1,5 @@
 {
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 328,

--- a/src/services/comcast.json
+++ b/src/services/comcast.json
@@ -1,7 +1,13 @@
 {
   "alexa": 8108,
   "class": "",
-  "crawls": [],
+  "crawls": [
+    "comcast.com/Acceptable Use Policy for Xfinity Internet.txt",
+    "comcast.com/Customer Privacy Policy.txt",
+    "comcast.com/Privacy Policy.txt",
+    "comcast.com/Privacy Statement.txt",
+    "comcast.com/Residential Subscriber Agreement.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/comcast.json
+++ b/src/services/comcast.json
@@ -1,6 +1,7 @@
 {
   "alexa": 8108,
   "class": "",
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/couchsurfing.json
+++ b/src/services/couchsurfing.json
@@ -1,5 +1,6 @@
 {
   "alexa": 219946,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/coursera.json
+++ b/src/services/coursera.json
@@ -1,5 +1,6 @@
 {
   "alexa": 698,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 209,

--- a/src/services/coursera.json
+++ b/src/services/coursera.json
@@ -1,6 +1,8 @@
 {
   "alexa": 698,
-  "crawls": [],
+  "crawls": [
+    "coursera.org/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 209,

--- a/src/services/coveredca.json
+++ b/src/services/coveredca.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 402,

--- a/src/services/cox.json
+++ b/src/services/cox.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 434,

--- a/src/services/craigslist.json
+++ b/src/services/craigslist.json
@@ -1,6 +1,8 @@
 {
   "alexa": 105,
-  "crawls": [],
+  "crawls": [
+    "craigslist.org/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 159,

--- a/src/services/craigslist.json
+++ b/src/services/craigslist.json
@@ -1,5 +1,6 @@
 {
   "alexa": 105,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 159,

--- a/src/services/creditkarma.json
+++ b/src/services/creditkarma.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1199,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 460,

--- a/src/services/creditnerds.json
+++ b/src/services/creditnerds.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/crowdtilt.json
+++ b/src/services/crowdtilt.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 373,

--- a/src/services/daybreakgames.json
+++ b/src/services/daybreakgames.json
@@ -1,5 +1,6 @@
 {
   "alexa": 12319,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/delicious.json
+++ b/src/services/delicious.json
@@ -7,6 +7,7 @@
     "0oKZG_o_Zu0",
     "aXOIDbzevYE"
   ],
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/delicious.json
+++ b/src/services/delicious.json
@@ -7,7 +7,10 @@
     "0oKZG_o_Zu0",
     "aXOIDbzevYE"
   ],
-  "crawls": [],
+  "crawls": [
+    "delicious.com/Privacy Policy.txt",
+    "delicious.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/dell-support.json
+++ b/src/services/dell-support.json
@@ -1,6 +1,9 @@
 {
   "alexa": 440,
-  "crawls": [],
+  "crawls": [
+    "dell.com/Consumer Terms of Sale.txt",
+    "dell.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/dell-support.json
+++ b/src/services/dell-support.json
@@ -1,5 +1,6 @@
 {
   "alexa": 440,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/deviantart.json
+++ b/src/services/deviantart.json
@@ -1,6 +1,11 @@
 {
   "alexa": 168,
-  "crawls": [],
+  "crawls": [
+    "deviantart.com/Copyright Policy.txt",
+    "deviantart.com/Etiquette Policy.txt",
+    "deviantart.com/Privacy Policy.txt",
+    "deviantart.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 192,

--- a/src/services/deviantart.json
+++ b/src/services/deviantart.json
@@ -1,5 +1,6 @@
 {
   "alexa": 168,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 192,

--- a/src/services/diasp-org.json
+++ b/src/services/diasp-org.json
@@ -1,6 +1,7 @@
 {
   "alexa": 189894,
   "class": "",
+  "crawls": [],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/dictionary-com.json
+++ b/src/services/dictionary-com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 523,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 320,

--- a/src/services/dictionary-com.json
+++ b/src/services/dictionary-com.json
@@ -1,6 +1,8 @@
 {
   "alexa": 523,
-  "crawls": [],
+  "crawls": [
+    "dictionary.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 320,

--- a/src/services/dictionary.json
+++ b/src/services/dictionary.json
@@ -1,6 +1,8 @@
 {
   "alexa": 523,
-  "crawls": [],
+  "crawls": [
+    "dictionary.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 492,

--- a/src/services/dictionary.json
+++ b/src/services/dictionary.json
@@ -1,5 +1,6 @@
 {
   "alexa": 523,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 492,

--- a/src/services/diigo.json
+++ b/src/services/diigo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 11234,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/disqus.json
+++ b/src/services/disqus.json
@@ -1,5 +1,6 @@
 {
   "alexa": 759,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 239,

--- a/src/services/disqus.json
+++ b/src/services/disqus.json
@@ -1,6 +1,9 @@
 {
   "alexa": 759,
-  "crawls": [],
+  "crawls": [
+    "disqus.com/Privacy Policy.txt",
+    "disqus.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 239,

--- a/src/services/drf.json
+++ b/src/services/drf.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 431,

--- a/src/services/dropbox.json
+++ b/src/services/dropbox.json
@@ -1,5 +1,6 @@
 {
   "alexa": 97,
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/dropbox.json
+++ b/src/services/dropbox.json
@@ -1,6 +1,8 @@
 {
   "alexa": 97,
-  "crawls": [],
+  "crawls": [
+    "dropbox.com/Privacy Policy.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/duckduckgo.json
+++ b/src/services/duckduckgo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 331,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 222,

--- a/src/services/duckduckgo.json
+++ b/src/services/duckduckgo.json
@@ -1,6 +1,8 @@
 {
   "alexa": 331,
-  "crawls": [],
+  "crawls": [
+    "duckduckgo.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 222,

--- a/src/services/easynews.json
+++ b/src/services/easynews.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 451,

--- a/src/services/ebay.json
+++ b/src/services/ebay.json
@@ -1,6 +1,9 @@
 {
   "alexa": 40,
-  "crawls": [],
+  "crawls": [
+    "ebay.com/Privacy Policy.txt",
+    "ebay.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 226,

--- a/src/services/ebay.json
+++ b/src/services/ebay.json
@@ -1,5 +1,6 @@
 {
   "alexa": 40,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 226,

--- a/src/services/ebuddy.json
+++ b/src/services/ebuddy.json
@@ -1,5 +1,6 @@
 {
   "alexa": 412003,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/educreations.json
+++ b/src/services/educreations.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 468,

--- a/src/services/elance.json
+++ b/src/services/elance.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 368,

--- a/src/services/ello.json
+++ b/src/services/ello.json
@@ -1,5 +1,6 @@
 {
   "alexa": 43737,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/em-client.json
+++ b/src/services/em-client.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 432,

--- a/src/services/energyhelpline.json
+++ b/src/services/energyhelpline.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 357,

--- a/src/services/enjin.json
+++ b/src/services/enjin.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 450,

--- a/src/services/envato.json
+++ b/src/services/envato.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1345,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 245,

--- a/src/services/etesync.json
+++ b/src/services/etesync.json
@@ -1,4 +1,5 @@
 {
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 329,

--- a/src/services/etsy.json
+++ b/src/services/etsy.json
@@ -1,5 +1,6 @@
 {
   "alexa": 169,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 243,

--- a/src/services/etsy.json
+++ b/src/services/etsy.json
@@ -1,6 +1,8 @@
 {
   "alexa": 169,
-  "crawls": [],
+  "crawls": [
+    "etsy.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 243,

--- a/src/services/eve-online.json
+++ b/src/services/eve-online.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 361,

--- a/src/services/evernote.json
+++ b/src/services/evernote.json
@@ -1,5 +1,6 @@
 {
   "alexa": 512,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/everpix.json
+++ b/src/services/everpix.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 422,

--- a/src/services/experteer.json
+++ b/src/services/experteer.json
@@ -1,5 +1,6 @@
 {
   "alexa": 78924,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 298,

--- a/src/services/facebook.json
+++ b/src/services/facebook.json
@@ -1,6 +1,9 @@
 {
   "alexa": 3,
-  "crawls": [],
+  "crawls": [
+    "facebook.com/Data Use Policy.txt",
+    "facebook.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 182,

--- a/src/services/facebook.json
+++ b/src/services/facebook.json
@@ -1,5 +1,6 @@
 {
   "alexa": 3,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 182,

--- a/src/services/fairpoint.json
+++ b/src/services/fairpoint.json
@@ -1,6 +1,8 @@
 {
   "alexa": 234057,
-  "crawls": [],
+  "crawls": [
+    "fairpoint.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 223,

--- a/src/services/fairpoint.json
+++ b/src/services/fairpoint.json
@@ -1,5 +1,6 @@
 {
   "alexa": 234057,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 223,

--- a/src/services/fc2.json
+++ b/src/services/fc2.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 473,

--- a/src/services/feedly.json
+++ b/src/services/feedly.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 405,

--- a/src/services/fetster.json
+++ b/src/services/fetster.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 249,

--- a/src/services/fifa-com.json
+++ b/src/services/fifa-com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 475,

--- a/src/services/fightforthefuture.org.json
+++ b/src/services/fightforthefuture.org.json
@@ -1,5 +1,6 @@
 {
   "alexa": 120549,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 178,

--- a/src/services/firefox-accounts.json
+++ b/src/services/firefox-accounts.json
@@ -1,5 +1,6 @@
 {
   "alexa": 3078,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/fitbit.json
+++ b/src/services/fitbit.json
@@ -1,6 +1,8 @@
 {
   "alexa": 1965,
-  "crawls": [],
+  "crawls": [
+    "fitbit.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 336,

--- a/src/services/fitbit.json
+++ b/src/services/fitbit.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1965,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 336,

--- a/src/services/fitocracy.json
+++ b/src/services/fitocracy.json
@@ -1,5 +1,6 @@
 {
   "alexa": 155653,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 189,

--- a/src/services/fitocracy.json
+++ b/src/services/fitocracy.json
@@ -1,6 +1,8 @@
 {
   "alexa": 155653,
-  "crawls": [],
+  "crawls": [
+    "fitocracy.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 189,

--- a/src/services/fivesquid.json
+++ b/src/services/fivesquid.json
@@ -1,5 +1,6 @@
 {
   "alexa": 88552,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 459,

--- a/src/services/fivesquids.json
+++ b/src/services/fivesquids.json
@@ -1,4 +1,5 @@
 {
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 235,

--- a/src/services/flattr.json
+++ b/src/services/flattr.json
@@ -1,5 +1,6 @@
 {
   "alexa": 100428,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/flickr.json
+++ b/src/services/flickr.json
@@ -1,5 +1,6 @@
 {
   "alexa": 365,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 186,

--- a/src/services/flickr.json
+++ b/src/services/flickr.json
@@ -1,6 +1,10 @@
 {
   "alexa": 365,
-  "crawls": [],
+  "crawls": [
+    "flickr.com/Additional Terms of Service.txt",
+    "flickr.com/Community Guidelines.txt",
+    "flickr.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 186,

--- a/src/services/flist.json
+++ b/src/services/flist.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 390,

--- a/src/services/fotocommunity.json
+++ b/src/services/fotocommunity.json
@@ -1,5 +1,6 @@
 {
   "alexa": 17428,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 344,

--- a/src/services/foursquare.json
+++ b/src/services/foursquare.json
@@ -1,6 +1,7 @@
 {
   "alexa": 2552,
   "class": "",
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/foxnews.json
+++ b/src/services/foxnews.json
@@ -1,6 +1,9 @@
 {
   "alexa": 260,
-  "crawls": [],
+  "crawls": [
+    "foxnews.com/Privacy Policy.txt",
+    "foxnews.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 317,

--- a/src/services/foxnews.json
+++ b/src/services/foxnews.json
@@ -1,5 +1,6 @@
 {
   "alexa": 260,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 317,

--- a/src/services/freeforums.json
+++ b/src/services/freeforums.json
@@ -1,6 +1,8 @@
 {
   "alexa": 787377,
-  "crawls": [],
+  "crawls": [
+    "freeforums.org/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/freeforums.json
+++ b/src/services/freeforums.json
@@ -1,5 +1,6 @@
 {
   "alexa": 787377,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/fruux.json
+++ b/src/services/fruux.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/furaffinity.json
+++ b/src/services/furaffinity.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 403,

--- a/src/services/furrymate.json
+++ b/src/services/furrymate.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 463,

--- a/src/services/github.json
+++ b/src/services/github.json
@@ -1,6 +1,10 @@
 {
   "alexa": 73,
-  "crawls": [],
+  "crawls": [
+    "github.com/Privacy Policy.txt",
+    "github.com/Security.txt",
+    "github.com/Terms of Service.txt"
+  ],
   "dataexport": true,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/github.json
+++ b/src/services/github.json
@@ -1,5 +1,6 @@
 {
   "alexa": 73,
+  "crawls": [],
   "dataexport": true,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/gitorious.json
+++ b/src/services/gitorious.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 472,

--- a/src/services/gittip.json
+++ b/src/services/gittip.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 375,

--- a/src/services/godaddy.json
+++ b/src/services/godaddy.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 347,

--- a/src/services/goodreads.json
+++ b/src/services/goodreads.json
@@ -1,5 +1,6 @@
 {
   "alexa": 310,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 165,

--- a/src/services/goodreads.json
+++ b/src/services/goodreads.json
@@ -1,6 +1,8 @@
 {
   "alexa": 310,
-  "crawls": [],
+  "crawls": [
+    "goodreads.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 165,

--- a/src/services/google-fiber.json
+++ b/src/services/google-fiber.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 495,

--- a/src/services/google.json
+++ b/src/services/google.json
@@ -1,6 +1,16 @@
 {
   "alexa": 1,
-  "crawls": [],
+  "crawls": [
+    "google.com/Google Analytics Terms of Service.txt",
+    "google.com/Privacy Policy.txt",
+    "google.com/Terms of Service.txt",
+    "google.de/Privacy Policy.txt",
+    "google.co.uk/Privacy Policy.txt",
+    "google.com.br/Privacy Policy.txt",
+    "google.fr/Privacy Policy.txt",
+    "google.ca/Privacy Policy.txt",
+    "google.nl/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 217,

--- a/src/services/google.json
+++ b/src/services/google.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 217,

--- a/src/services/grammarly.json
+++ b/src/services/grammarly.json
@@ -1,6 +1,9 @@
 {
   "alexa": 818,
-  "crawls": [],
+  "crawls": [
+    "grammarly.com/Privacy Policy.txt",
+    "grammarly.com/Terms of Service and License Agreement.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 277,

--- a/src/services/grammarly.json
+++ b/src/services/grammarly.json
@@ -1,5 +1,6 @@
 {
   "alexa": 818,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 277,

--- a/src/services/grasscity.json
+++ b/src/services/grasscity.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 352,

--- a/src/services/gravatar.json
+++ b/src/services/gravatar.json
@@ -1,5 +1,6 @@
 {
   "alexa": 6187,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/greenisbetter.json
+++ b/src/services/greenisbetter.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/grooveshark.json
+++ b/src/services/grooveshark.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 424,

--- a/src/services/groupon.json
+++ b/src/services/groupon.json
@@ -1,6 +1,8 @@
 {
   "alexa": 513,
-  "crawls": [],
+  "crawls": [
+    "groupon.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 289,

--- a/src/services/groupon.json
+++ b/src/services/groupon.json
@@ -1,5 +1,6 @@
 {
   "alexa": 513,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 289,

--- a/src/services/gumtree.json
+++ b/src/services/gumtree.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 378,

--- a/src/services/habbo.json
+++ b/src/services/habbo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 33975,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/habbo.json
+++ b/src/services/habbo.json
@@ -1,6 +1,8 @@
 {
   "alexa": 33975,
-  "crawls": [],
+  "crawls": [
+    "habbo.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/heavenhr.json
+++ b/src/services/heavenhr.json
@@ -1,5 +1,6 @@
 {
   "alexa": 171417,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 444,

--- a/src/services/huffingtonpost.json
+++ b/src/services/huffingtonpost.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 490,

--- a/src/services/hulu.json
+++ b/src/services/hulu.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 348,

--- a/src/services/hypster.json
+++ b/src/services/hypster.json
@@ -1,5 +1,6 @@
 {
   "alexa": 88581,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/icloud.json
+++ b/src/services/icloud.json
@@ -1,5 +1,6 @@
 {
   "alexa": 373,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 291,

--- a/src/services/identi-ca.json
+++ b/src/services/identi-ca.json
@@ -1,6 +1,7 @@
 {
   "alexa": 414420,
   "class": "",
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/identica.json
+++ b/src/services/identica.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 367,

--- a/src/services/ifttt.json
+++ b/src/services/ifttt.json
@@ -1,5 +1,6 @@
 {
   "alexa": 3749,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/imdb.json
+++ b/src/services/imdb.json
@@ -1,6 +1,9 @@
 {
   "alexa": 49,
-  "crawls": [],
+  "crawls": [
+    "imdb.com/Privacy Policy.txt",
+    "imdb.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 313,

--- a/src/services/imdb.json
+++ b/src/services/imdb.json
@@ -1,5 +1,6 @@
 {
   "alexa": 49,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 313,

--- a/src/services/imgur.json
+++ b/src/services/imgur.json
@@ -1,5 +1,6 @@
 {
   "alexa": 46,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 325,

--- a/src/services/imgur.json
+++ b/src/services/imgur.json
@@ -1,6 +1,9 @@
 {
   "alexa": 46,
-  "crawls": [],
+  "crawls": [
+    "imgur.com/Privacy Policy.txt",
+    "imgur.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 325,

--- a/src/services/indabamusic.json
+++ b/src/services/indabamusic.json
@@ -1,5 +1,6 @@
 {
   "alexa": 272530,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/indeed.com.json
+++ b/src/services/indeed.com.json
@@ -1,6 +1,8 @@
 {
   "alexa": 199,
-  "crawls": [],
+  "crawls": [
+    "indeed.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 302,

--- a/src/services/indeed.com.json
+++ b/src/services/indeed.com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 199,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 302,

--- a/src/services/indiegogo.json
+++ b/src/services/indiegogo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2104,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 167,

--- a/src/services/informe.json
+++ b/src/services/informe.json
@@ -1,5 +1,6 @@
 {
   "alexa": 154315,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 478,

--- a/src/services/instagram.json
+++ b/src/services/instagram.json
@@ -3,7 +3,10 @@
   "clause": [
     "wy9QcF5zQII"
   ],
-  "crawls": [],
+  "crawls": [
+    "instagram.com/Privacy Policy.txt",
+    "instagram.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/instagram.json
+++ b/src/services/instagram.json
@@ -3,6 +3,7 @@
   "clause": [
     "wy9QcF5zQII"
   ],
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/inter-chat.json
+++ b/src/services/inter-chat.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 441,

--- a/src/services/interparcel.json
+++ b/src/services/interparcel.json
@@ -1,5 +1,6 @@
 {
   "alexa": 101475,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 256,

--- a/src/services/isis-mobile-wallet.json
+++ b/src/services/isis-mobile-wallet.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 401,

--- a/src/services/ixquick.json
+++ b/src/services/ixquick.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 483,

--- a/src/services/jacplus.json
+++ b/src/services/jacplus.json
@@ -1,5 +1,6 @@
 {
   "alexa": 352203,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/jagex.json
+++ b/src/services/jagex.json
@@ -1,5 +1,6 @@
 {
   "alexa": 13641,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 332,

--- a/src/services/jawbone.json
+++ b/src/services/jawbone.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 346,

--- a/src/services/jobvite.json
+++ b/src/services/jobvite.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 394,

--- a/src/services/joindiaspora-com.json
+++ b/src/services/joindiaspora-com.json
@@ -1,6 +1,7 @@
 {
   "alexa": 243894,
   "class": "",
+  "crawls": [],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/justpark.json
+++ b/src/services/justpark.json
@@ -1,5 +1,6 @@
 {
   "alexa": 94630,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/keybase.json
+++ b/src/services/keybase.json
@@ -1,5 +1,6 @@
 {
   "alexa": 75079,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 404,

--- a/src/services/kickstarter.json
+++ b/src/services/kickstarter.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 362,

--- a/src/services/kik-messenger.json
+++ b/src/services/kik-messenger.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 358,

--- a/src/services/kilu.json
+++ b/src/services/kilu.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 387,

--- a/src/services/king.json
+++ b/src/services/king.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 453,

--- a/src/services/kippt.json
+++ b/src/services/kippt.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 497,

--- a/src/services/kixeye.json
+++ b/src/services/kixeye.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 377,

--- a/src/services/koding.json
+++ b/src/services/koding.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 415,

--- a/src/services/kolabnow.json
+++ b/src/services/kolabnow.json
@@ -1,5 +1,6 @@
 {
   "alexa": 504997,
+  "crawls": [],
   "freesoftware": true,
   "fulltos": {},
   "id": 246,

--- a/src/services/kongregate.json
+++ b/src/services/kongregate.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 443,

--- a/src/services/last.fm.json
+++ b/src/services/last.fm.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1416,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 253,

--- a/src/services/last.fm.json
+++ b/src/services/last.fm.json
@@ -1,6 +1,8 @@
 {
   "alexa": 1416,
-  "crawls": [],
+  "crawls": [
+    "last.fm/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 253,

--- a/src/services/lastpass.json
+++ b/src/services/lastpass.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2690,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 161,

--- a/src/services/leagueoflegends.json
+++ b/src/services/leagueoflegends.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 369,

--- a/src/services/letsencrypt.json
+++ b/src/services/letsencrypt.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 484,

--- a/src/services/lfichier.json
+++ b/src/services/lfichier.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 360,

--- a/src/services/librarything.json
+++ b/src/services/librarything.json
@@ -1,5 +1,6 @@
 {
   "alexa": 22343,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/linkedin.json
+++ b/src/services/linkedin.json
@@ -1,6 +1,9 @@
 {
   "alexa": 33,
-  "crawls": [],
+  "crawls": [
+    "linkedin.com/Privacy Policy.txt",
+    "linkedin.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/linkedin.json
+++ b/src/services/linkedin.json
@@ -1,5 +1,6 @@
 {
   "alexa": 33,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/live.json
+++ b/src/services/live.json
@@ -1,5 +1,6 @@
 {
   "alexa": 15,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 379,

--- a/src/services/live.json
+++ b/src/services/live.json
@@ -1,6 +1,9 @@
 {
   "alexa": 15,
-  "crawls": [],
+  "crawls": [
+    "live.com/Microsoft Services Agreement.txt",
+    "live.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 379,

--- a/src/services/livejournal.json
+++ b/src/services/livejournal.json
@@ -1,5 +1,6 @@
 {
   "alexa": 272,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 261,

--- a/src/services/livejournal.json
+++ b/src/services/livejournal.json
@@ -1,6 +1,9 @@
 {
   "alexa": 272,
-  "crawls": [],
+  "crawls": [
+    "livejournal.com/Privacy Policy.txt",
+    "livejournal.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 261,

--- a/src/services/looki.json
+++ b/src/services/looki.json
@@ -1,5 +1,6 @@
 {
   "alexa": 392233,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 339,

--- a/src/services/loopt.json
+++ b/src/services/loopt.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/lorea.json
+++ b/src/services/lorea.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 433,

--- a/src/services/lyft.json
+++ b/src/services/lyft.json
@@ -1,5 +1,6 @@
 {
   "alexa": 6909,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/makeuseof-deals.json
+++ b/src/services/makeuseof-deals.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1523,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/meetup.json
+++ b/src/services/meetup.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 411,

--- a/src/services/mega.json
+++ b/src/services/mega.json
@@ -1,5 +1,6 @@
 {
   "alexa": 118262,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 306,

--- a/src/services/microsoft-store.json
+++ b/src/services/microsoft-store.json
@@ -1,5 +1,6 @@
 {
   "alexa": 47,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 202,

--- a/src/services/microsoft-store.json
+++ b/src/services/microsoft-store.json
@@ -1,6 +1,9 @@
 {
   "alexa": 47,
-  "crawls": [],
+  "crawls": [
+    "microsoft.com/Privacy Policy.txt",
+    "microsoft.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 202,

--- a/src/services/microsoft.json
+++ b/src/services/microsoft.json
@@ -1,6 +1,9 @@
 {
   "alexa": 47,
-  "crawls": [],
+  "crawls": [
+    "microsoft.com/Privacy Policy.txt",
+    "microsoft.com/Terms of Service.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/microsoft.json
+++ b/src/services/microsoft.json
@@ -1,5 +1,6 @@
 {
   "alexa": 47,
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 1,

--- a/src/services/mimobaby.json
+++ b/src/services/mimobaby.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/minecraft.json
+++ b/src/services/minecraft.json
@@ -1,6 +1,8 @@
 {
   "alexa": 1451,
-  "crawls": [],
+  "crawls": [
+    "minecraft.net/Terms and Conditions.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/minecraft.json
+++ b/src/services/minecraft.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1451,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/mint.com.json
+++ b/src/services/mint.com.json
@@ -1,6 +1,10 @@
 {
   "alexa": 2765,
-  "crawls": [],
+  "crawls": [
+    "mint.com/Legal Information (Intuit).txt",
+    "mint.com/Privacy Policy.txt",
+    "mint.com/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 197,

--- a/src/services/mint.com.json
+++ b/src/services/mint.com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2765,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 197,

--- a/src/services/minuscom.json
+++ b/src/services/minuscom.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 371,

--- a/src/services/mitfahrgelegenheit.json
+++ b/src/services/mitfahrgelegenheit.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 448,

--- a/src/services/mobilitytrip.json
+++ b/src/services/mobilitytrip.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 392,

--- a/src/services/mondosol.json
+++ b/src/services/mondosol.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 438,

--- a/src/services/mozilla-persona.json
+++ b/src/services/mozilla-persona.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 426,

--- a/src/services/mozilla.json
+++ b/src/services/mozilla.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 439,

--- a/src/services/multiple.json
+++ b/src/services/multiple.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 428,

--- a/src/services/myspace.json
+++ b/src/services/myspace.json
@@ -1,6 +1,7 @@
 {
   "alexa": 4276,
   "class": "",
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/myspace.json
+++ b/src/services/myspace.json
@@ -1,7 +1,10 @@
 {
   "alexa": 4276,
   "class": "",
-  "crawls": [],
+  "crawls": [
+    "myspace.com/Privacy Policy.txt",
+    "myspace.com/Terms of Service.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/nabble.json
+++ b/src/services/nabble.json
@@ -1,5 +1,6 @@
 {
   "alexa": 7885,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 166,

--- a/src/services/nanowrimo.json
+++ b/src/services/nanowrimo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 467,

--- a/src/services/netflix.json
+++ b/src/services/netflix.json
@@ -1,5 +1,6 @@
 {
   "alexa": 30,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/netflix.json
+++ b/src/services/netflix.json
@@ -1,6 +1,9 @@
 {
   "alexa": 30,
-  "crawls": [],
+  "crawls": [
+    "netflix.com/Privacy Policy.txt",
+    "netflix.com/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/newsblur.json
+++ b/src/services/newsblur.json
@@ -1,5 +1,6 @@
 {
   "alexa": 29655,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/nokia.json
+++ b/src/services/nokia.json
@@ -1,5 +1,6 @@
 {
   "alexa": 4787,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 308,

--- a/src/services/npr.json
+++ b/src/services/npr.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 359,

--- a/src/services/nxpay.json
+++ b/src/services/nxpay.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 442,

--- a/src/services/nytimes.json
+++ b/src/services/nytimes.json
@@ -1,6 +1,8 @@
 {
   "alexa": 109,
-  "crawls": [],
+  "crawls": [
+    "nytimes.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 354,

--- a/src/services/nytimes.json
+++ b/src/services/nytimes.json
@@ -1,5 +1,6 @@
 {
   "alexa": 109,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 354,

--- a/src/services/olx.json
+++ b/src/services/olx.json
@@ -1,5 +1,6 @@
 {
   "alexa": 57736,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 341,

--- a/src/services/olx.json
+++ b/src/services/olx.json
@@ -1,6 +1,8 @@
 {
   "alexa": 57736,
-  "crawls": [],
+  "crawls": [
+    "olx.com/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 341,

--- a/src/services/onemorestorygames.json
+++ b/src/services/onemorestorygames.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/online-convert.json
+++ b/src/services/online-convert.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1335,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/onlive.json
+++ b/src/services/onlive.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 419,

--- a/src/services/openmailbox.json
+++ b/src/services/openmailbox.json
@@ -1,5 +1,6 @@
 {
   "alexa": 96145,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/openstreetmap.json
+++ b/src/services/openstreetmap.json
@@ -1,6 +1,7 @@
 {
   "alexa": 8048,
   "class": "",
+  "crawls": [],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/owncube.json
+++ b/src/services/owncube.json
@@ -1,6 +1,9 @@
 {
   "alexa": 537115,
-  "crawls": [],
+  "crawls": [
+    "owncube.com/Privacy.txt",
+    "owncube.com/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 279,

--- a/src/services/owncube.json
+++ b/src/services/owncube.json
@@ -1,5 +1,6 @@
 {
   "alexa": 537115,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 279,

--- a/src/services/packagetrackr.json
+++ b/src/services/packagetrackr.json
@@ -1,5 +1,6 @@
 {
   "alexa": 16913,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 350,

--- a/src/services/pagebin.json
+++ b/src/services/pagebin.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 488,

--- a/src/services/path.json
+++ b/src/services/path.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 496,

--- a/src/services/paypal.json
+++ b/src/services/paypal.json
@@ -1,6 +1,7 @@
 {
   "alexa": 66,
   "class": "",
+  "crawls": [],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/paypal.json
+++ b/src/services/paypal.json
@@ -1,7 +1,9 @@
 {
   "alexa": 66,
   "class": "",
-  "crawls": [],
+  "crawls": [
+    "paypal.com/Privacy Policy.txt"
+  ],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/pcrate.json
+++ b/src/services/pcrate.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 408,

--- a/src/services/pebble.json
+++ b/src/services/pebble.json
@@ -1,5 +1,6 @@
 {
   "alexa": 133072,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 440,

--- a/src/services/pgoh13.json
+++ b/src/services/pgoh13.json
@@ -1,5 +1,6 @@
 {
   "alexa": 995384,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/phpbb.json
+++ b/src/services/phpbb.json
@@ -1,5 +1,6 @@
 {
   "alexa": 50975,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/piazzacom.json
+++ b/src/services/piazzacom.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 479,

--- a/src/services/pinterest.json
+++ b/src/services/pinterest.json
@@ -1,5 +1,6 @@
 {
   "alexa": 77,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 175,

--- a/src/services/pinterest.json
+++ b/src/services/pinterest.json
@@ -1,6 +1,9 @@
 {
   "alexa": 77,
-  "crawls": [],
+  "crawls": [
+    "pinterest.com/Privacy Policy.txt",
+    "pinterest.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 175,

--- a/src/services/pixabay.json
+++ b/src/services/pixabay.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 458,

--- a/src/services/plenti.json
+++ b/src/services/plenti.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 420,

--- a/src/services/pocket.json
+++ b/src/services/pocket.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 384,

--- a/src/services/proboards.json
+++ b/src/services/proboards.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 449,

--- a/src/services/protonmail.json
+++ b/src/services/protonmail.json
@@ -1,5 +1,6 @@
 {
   "alexa": 3367,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 491,

--- a/src/services/pure.json
+++ b/src/services/pure.json
@@ -1,5 +1,6 @@
 {
   "alexa": 573223,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/pushbullet.json
+++ b/src/services/pushbullet.json
@@ -1,5 +1,6 @@
 {
   "alexa": 7990,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/quake.json
+++ b/src/services/quake.json
@@ -1,5 +1,6 @@
 {
   "alexa": 306927,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 338,

--- a/src/services/quake.json
+++ b/src/services/quake.json
@@ -1,6 +1,11 @@
 {
   "alexa": 306927,
-  "crawls": [],
+  "crawls": [
+    "quakelive.com/EULA.txt",
+    "quakelive.com/Legal Notices.txt",
+    "quakelive.com/Privacy Policy.txt",
+    "quakelive.com/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 338,

--- a/src/services/quickbooks.json
+++ b/src/services/quickbooks.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/quora.json
+++ b/src/services/quora.json
@@ -1,5 +1,6 @@
 {
   "alexa": 141,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 314,

--- a/src/services/quora.json
+++ b/src/services/quora.json
@@ -1,6 +1,8 @@
 {
   "alexa": 141,
-  "crawls": [],
+  "crawls": [
+    "quora.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 314,

--- a/src/services/rac.json
+++ b/src/services/rac.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 414,

--- a/src/services/rapidshare.json
+++ b/src/services/rapidshare.json
@@ -1,5 +1,6 @@
 {
   "alexa": 229963,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 205,

--- a/src/services/reddit.json
+++ b/src/services/reddit.json
@@ -1,6 +1,9 @@
 {
   "alexa": 6,
-  "crawls": [],
+  "crawls": [
+    "reddit.com/Privacy Policy.txt",
+    "reddit.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 194,

--- a/src/services/reddit.json
+++ b/src/services/reddit.json
@@ -1,5 +1,6 @@
 {
   "alexa": 6,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 194,

--- a/src/services/reputation.com.json
+++ b/src/services/reputation.com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 95524,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 196,

--- a/src/services/reputation.com.json
+++ b/src/services/reputation.com.json
@@ -1,6 +1,9 @@
 {
   "alexa": 95524,
-  "crawls": [],
+  "crawls": [
+    "reputation.com/Privacy Policy.txt",
+    "reputation.com/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 196,

--- a/src/services/researchgate.json
+++ b/src/services/researchgate.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 380,

--- a/src/services/resilio.json
+++ b/src/services/resilio.json
@@ -1,5 +1,6 @@
 {
   "alexa": 58070,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 399,

--- a/src/services/restream.json
+++ b/src/services/restream.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 465,

--- a/src/services/ringplus.json
+++ b/src/services/ringplus.json
@@ -1,5 +1,6 @@
 {
   "alexa": 485104,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/riseup-net.json
+++ b/src/services/riseup-net.json
@@ -1,5 +1,6 @@
 {
   "alexa": 46101,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 327,

--- a/src/services/runescape.json
+++ b/src/services/runescape.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1647,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 199,

--- a/src/services/runtastic.json
+++ b/src/services/runtastic.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 499,

--- a/src/services/salesforce.json
+++ b/src/services/salesforce.json
@@ -1,6 +1,8 @@
 {
   "alexa": 158,
-  "crawls": [],
+  "crawls": [
+    "salesforce.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 216,

--- a/src/services/salesforce.json
+++ b/src/services/salesforce.json
@@ -1,5 +1,6 @@
 {
   "alexa": 158,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 216,

--- a/src/services/scotiabank.json
+++ b/src/services/scotiabank.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1761,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 285,

--- a/src/services/scrubly.json
+++ b/src/services/scrubly.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 466,

--- a/src/services/seenthis.json
+++ b/src/services/seenthis.json
@@ -1,5 +1,6 @@
 {
   "alexa": 653482,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 330,

--- a/src/services/sharemylesson.json
+++ b/src/services/sharemylesson.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 487,

--- a/src/services/sharetube.json
+++ b/src/services/sharetube.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 413,

--- a/src/services/shoppersphoto.json
+++ b/src/services/shoppersphoto.json
@@ -1,5 +1,6 @@
 {
   "alexa": 221955,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/sigfig.json
+++ b/src/services/sigfig.json
@@ -1,5 +1,6 @@
 {
   "alexa": 77269,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/simplehitcounter.json
+++ b/src/services/simplehitcounter.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 383,

--- a/src/services/skype.json
+++ b/src/services/skype.json
@@ -1,5 +1,6 @@
 {
   "alexa": 367,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 204,

--- a/src/services/skype.json
+++ b/src/services/skype.json
@@ -1,6 +1,22 @@
 {
   "alexa": 367,
-  "crawls": [],
+  "crawls": [
+    "skype.com/Business End User License Agreement (US).txt",
+    "skype.com/Business End User License Agreement.txt",
+    "skype.com/Cookies Policy.txt",
+    "skype.com/Etiquette.txt",
+    "skype.com/Fair Usage Policy for Subscriptions.txt",
+    "skype.com/Fair Usage Policy for US Minute Bundles.txt",
+    "skype.com/Group Video Calling Fair Usage Policy.txt",
+    "skype.com/Privacy Policies.txt",
+    "skype.com/Privacy Policy English (International).txt",
+    "skype.com/Skype Emergency Calling.txt",
+    "skype.com/Terms and Policies.txt",
+    "skype.com/Terms of Service - Business (US).txt",
+    "skype.com/Terms of Service - Business.txt",
+    "skype.com/Terms of Use.txt",
+    "skype.com/Trademark Guidelines.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 204,

--- a/src/services/slack.json
+++ b/src/services/slack.json
@@ -1,5 +1,6 @@
 {
   "alexa": 275,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/snapchat.json
+++ b/src/services/snapchat.json
@@ -1,5 +1,6 @@
 {
   "alexa": 4606,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 311,

--- a/src/services/softpedia.json
+++ b/src/services/softpedia.json
@@ -1,6 +1,8 @@
 {
   "alexa": 2046,
-  "crawls": [],
+  "crawls": [
+    "softpedia.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 163,

--- a/src/services/softpedia.json
+++ b/src/services/softpedia.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2046,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 163,

--- a/src/services/sonic-net.json
+++ b/src/services/sonic-net.json
@@ -1,6 +1,7 @@
 {
   "alexa": 83111,
   "class": "",
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 286,

--- a/src/services/sonic-net.json
+++ b/src/services/sonic-net.json
@@ -1,7 +1,9 @@
 {
   "alexa": 83111,
   "class": "",
-  "crawls": [],
+  "crawls": [
+    "sonic.net/All Policies.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 286,

--- a/src/services/sony.json
+++ b/src/services/sony.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 457,

--- a/src/services/soundcloud.json
+++ b/src/services/soundcloud.json
@@ -1,6 +1,10 @@
 {
   "alexa": 106,
-  "crawls": [],
+  "crawls": [
+    "soundcloud.com/Community Guidelines.txt",
+    "soundcloud.com/Privacy Policy.txt",
+    "soundcloud.com/Terms of Service.txt"
+  ],
   "dataexport": true,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/soundcloud.json
+++ b/src/services/soundcloud.json
@@ -1,5 +1,6 @@
 {
   "alexa": 106,
+  "crawls": [],
   "dataexport": true,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/sourceforge.json
+++ b/src/services/sourceforge.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 356,

--- a/src/services/spideroak.json
+++ b/src/services/spideroak.json
@@ -1,6 +1,7 @@
 {
   "alexa": 95890,
   "class": "",
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/spotify.json
+++ b/src/services/spotify.json
@@ -1,6 +1,12 @@
 {
   "alexa": 121,
-  "crawls": [],
+  "crawls": [
+    "spotify.com/Privacy Policy.txt",
+    "spotify.com/Terms and Conditions (Mobile).txt",
+    "spotify.com/Terms and Conditions (Premium).txt",
+    "spotify.com/Terms and Conditions (Unlimited).txt",
+    "spotify.com/Terms and Conditions of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 225,

--- a/src/services/spotify.json
+++ b/src/services/spotify.json
@@ -1,5 +1,6 @@
 {
   "alexa": 121,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 225,

--- a/src/services/sprint.json
+++ b/src/services/sprint.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 446,

--- a/src/services/square.json
+++ b/src/services/square.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2687,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 464,

--- a/src/services/stackexchange.json
+++ b/src/services/stackexchange.json
@@ -1,5 +1,6 @@
 {
   "alexa": 133,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 300,

--- a/src/services/stackexchange.json
+++ b/src/services/stackexchange.json
@@ -1,6 +1,12 @@
 {
   "alexa": 133,
-  "crawls": [],
+  "crawls": [
+    "stackexchange.com/APIs Terms of Use.txt",
+    "stackexchange.com/Content Policy.txt",
+    "stackexchange.com/Privacy Policy.txt",
+    "stackexchange.com/Terms of Service.txt",
+    "stackexchange.com/Trademark Guidance.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 300,

--- a/src/services/stackoverflow.json
+++ b/src/services/stackoverflow.json
@@ -1,5 +1,6 @@
 {
   "alexa": 76,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 312,

--- a/src/services/startpage.json
+++ b/src/services/startpage.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 418,

--- a/src/services/status-net.json
+++ b/src/services/status-net.json
@@ -1,5 +1,6 @@
 {
   "alexa": 130279,
+  "crawls": [],
   "federated": true,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/steam.json
+++ b/src/services/steam.json
@@ -1,6 +1,9 @@
 {
   "alexa": 154,
-  "crawls": [],
+  "crawls": [
+    "steampowered.com/Privacy Policy Agreement.txt",
+    "steampowered.com/Steam Subscriber Agreement.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 180,

--- a/src/services/steam.json
+++ b/src/services/steam.json
@@ -1,5 +1,6 @@
 {
   "alexa": 154,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 180,

--- a/src/services/storify.json
+++ b/src/services/storify.json
@@ -1,5 +1,6 @@
 {
   "alexa": 8403,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/strangertickets.json
+++ b/src/services/strangertickets.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 430,

--- a/src/services/stumble-upon.json
+++ b/src/services/stumble-upon.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 498,

--- a/src/services/styleseat.json
+++ b/src/services/styleseat.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 429,

--- a/src/services/sumome.json
+++ b/src/services/sumome.json
@@ -1,5 +1,6 @@
 {
   "alexa": 446618,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/symantec.json
+++ b/src/services/symantec.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 435,

--- a/src/services/symbaloo.json
+++ b/src/services/symbaloo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 4839,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 262,

--- a/src/services/taco.json
+++ b/src/services/taco.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 376,

--- a/src/services/tes-connect.json
+++ b/src/services/tes-connect.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 345,

--- a/src/services/theguardian.json
+++ b/src/services/theguardian.json
@@ -1,5 +1,6 @@
 {
   "alexa": 147,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 455,

--- a/src/services/theguardian.json
+++ b/src/services/theguardian.json
@@ -1,6 +1,8 @@
 {
   "alexa": 147,
-  "crawls": [],
+  "crawls": [
+    "theguardian.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 455,

--- a/src/services/themeforest.json
+++ b/src/services/themeforest.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 501,

--- a/src/services/tidyio.json
+++ b/src/services/tidyio.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 409,

--- a/src/services/tinder.json
+++ b/src/services/tinder.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1578,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 462,

--- a/src/services/tinkercad.json
+++ b/src/services/tinkercad.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 469,

--- a/src/services/tinyurl.json
+++ b/src/services/tinyurl.json
@@ -1,5 +1,6 @@
 {
   "alexa": 6635,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 229,

--- a/src/services/tinyurl.json
+++ b/src/services/tinyurl.json
@@ -1,6 +1,8 @@
 {
   "alexa": 6635,
-  "crawls": [],
+  "crawls": [
+    "tinyurl.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 229,

--- a/src/services/tmobile.json
+++ b/src/services/tmobile.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 355,

--- a/src/services/toggle.json
+++ b/src/services/toggle.json
@@ -1,5 +1,6 @@
 {
   "alexa": 154743,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 391,

--- a/src/services/toodledo.json
+++ b/src/services/toodledo.json
@@ -1,6 +1,9 @@
 {
   "alexa": 22616,
-  "crawls": [],
+  "crawls": [
+    "toodledo.com/Privacy Policy.txt",
+    "toodledo.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 160,

--- a/src/services/toodledo.json
+++ b/src/services/toodledo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 22616,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 160,

--- a/src/services/toryburch.json
+++ b/src/services/toryburch.json
@@ -1,5 +1,6 @@
 {
   "alexa": 15249,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/travelzoo.json
+++ b/src/services/travelzoo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 9439,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 425,

--- a/src/services/travelzoo.json
+++ b/src/services/travelzoo.json
@@ -1,6 +1,8 @@
 {
   "alexa": 9439,
-  "crawls": [],
+  "crawls": [
+    "travelzoo.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 425,

--- a/src/services/tripadvisor.json
+++ b/src/services/tripadvisor.json
@@ -1,6 +1,8 @@
 {
   "alexa": 289,
-  "crawls": [],
+  "crawls": [
+    "tripadvisor.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 382,

--- a/src/services/tripadvisor.json
+++ b/src/services/tripadvisor.json
@@ -1,5 +1,6 @@
 {
   "alexa": 289,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 382,

--- a/src/services/tumblr.json
+++ b/src/services/tumblr.json
@@ -1,6 +1,9 @@
 {
   "alexa": 53,
-  "crawls": [],
+  "crawls": [
+    "tumblr.com/Privacy Policy.txt",
+    "tumblr.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 280,

--- a/src/services/tumblr.json
+++ b/src/services/tumblr.json
@@ -1,5 +1,6 @@
 {
   "alexa": 53,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 280,

--- a/src/services/tutanota.json
+++ b/src/services/tutanota.json
@@ -1,5 +1,6 @@
 {
   "alexa": 20713,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/tweetdeck.json
+++ b/src/services/tweetdeck.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 381,

--- a/src/services/twitch.json
+++ b/src/services/twitch.json
@@ -1,5 +1,6 @@
 {
   "alexa": 37,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/twitpic.json
+++ b/src/services/twitpic.json
@@ -1,5 +1,6 @@
 {
   "alexa": 59948,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 301,

--- a/src/services/twitpic.json
+++ b/src/services/twitpic.json
@@ -1,6 +1,9 @@
 {
   "alexa": 59948,
-  "crawls": [],
+  "crawls": [
+    "twitpic.com/Privacy Policy.txt",
+    "twitpic.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 301,

--- a/src/services/twitter.json
+++ b/src/services/twitter.json
@@ -1,5 +1,6 @@
 {
   "alexa": 13,
+  "crawls": [],
   "dataexport": false,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/twitter.json
+++ b/src/services/twitter.json
@@ -1,6 +1,9 @@
 {
   "alexa": 13,
-  "crawls": [],
+  "crawls": [
+    "twitter.com/Privacy Policy.txt",
+    "twitter.com/Terms of Service.txt"
+  ],
   "dataexport": false,
   "freesoftware": false,
   "fulltos": {},

--- a/src/services/twitvid.json
+++ b/src/services/twitvid.json
@@ -1,5 +1,6 @@
 {
   "alexa": 890377,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 363,

--- a/src/services/typeform.json
+++ b/src/services/typeform.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 351,

--- a/src/services/uber.json
+++ b/src/services/uber.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1124,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/undefined.json
+++ b/src/services/undefined.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 366,

--- a/src/services/urban-dictionary.json
+++ b/src/services/urban-dictionary.json
@@ -1,5 +1,6 @@
 {
   "alexa": 567,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 324,

--- a/src/services/urban-dictionary.json
+++ b/src/services/urban-dictionary.json
@@ -1,6 +1,8 @@
 {
   "alexa": 567,
-  "crawls": [],
+  "crawls": [
+    "urbandictionary.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 324,

--- a/src/services/urbandictionary.json
+++ b/src/services/urbandictionary.json
@@ -1,5 +1,6 @@
 {
   "alexa": 567,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 398,

--- a/src/services/urbandictionary.json
+++ b/src/services/urbandictionary.json
@@ -1,6 +1,8 @@
 {
   "alexa": 567,
-  "crawls": [],
+  "crawls": [
+    "urbandictionary.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 398,

--- a/src/services/usacarry.json
+++ b/src/services/usacarry.json
@@ -1,5 +1,6 @@
 {
   "alexa": 98905,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/vbulletin.json
+++ b/src/services/vbulletin.json
@@ -1,5 +1,6 @@
 {
   "alexa": 103395,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/verizon.json
+++ b/src/services/verizon.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1350,
+  "crawls": [],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/verizon.json
+++ b/src/services/verizon.json
@@ -1,6 +1,9 @@
 {
   "alexa": 1350,
-  "crawls": [],
+  "crawls": [
+    "verizon.com/Privacy Policy.txt",
+    "verizon.com/Terms of Service.txt"
+  ],
   "date": "",
   "eff_hasyourback": {
     "in-Congress": 0,

--- a/src/services/vero.json
+++ b/src/services/vero.json
@@ -1,5 +1,6 @@
 {
   "alexa": 875341,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 334,

--- a/src/services/videobb.json
+++ b/src/services/videobb.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 342,

--- a/src/services/vimeo.json
+++ b/src/services/vimeo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 132,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/vimeo.json
+++ b/src/services/vimeo.json
@@ -1,6 +1,9 @@
 {
   "alexa": 132,
-  "crawls": [],
+  "crawls": [
+    "vimeo.com/Privacy Policy.txt",
+    "vimeo.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/virgin.json
+++ b/src/services/virgin.json
@@ -1,5 +1,6 @@
 {
   "alexa": 33655,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 427,

--- a/src/services/vk.json
+++ b/src/services/vk.json
@@ -1,5 +1,6 @@
 {
   "alexa": 14,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/vocaroo.json
+++ b/src/services/vocaroo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 410,

--- a/src/services/vudu.json
+++ b/src/services/vudu.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 412,

--- a/src/services/w3schools.json
+++ b/src/services/w3schools.json
@@ -1,5 +1,6 @@
 {
   "alexa": 216,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 319,

--- a/src/services/walmart.json
+++ b/src/services/walmart.json
@@ -1,5 +1,6 @@
 {
   "alexa": 163,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 445,

--- a/src/services/walmart.json
+++ b/src/services/walmart.json
@@ -1,6 +1,8 @@
 {
   "alexa": 163,
-  "crawls": [],
+  "crawls": [
+    "walmart.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 445,

--- a/src/services/waveapps.json
+++ b/src/services/waveapps.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 395,

--- a/src/services/waze.json
+++ b/src/services/waze.json
@@ -1,5 +1,6 @@
 {
   "alexa": 10451,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 221,

--- a/src/services/websaver.json
+++ b/src/services/websaver.json
@@ -1,5 +1,6 @@
 {
   "alexa": 490560,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 268,

--- a/src/services/weebly.json
+++ b/src/services/weebly.json
@@ -1,5 +1,6 @@
 {
   "alexa": 377,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 288,

--- a/src/services/weebly.json
+++ b/src/services/weebly.json
@@ -1,6 +1,9 @@
 {
   "alexa": 377,
-  "crawls": [],
+  "crawls": [
+    "weebly.com/Privacy Policy.txt",
+    "weebly.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 288,

--- a/src/services/weibo.json
+++ b/src/services/weibo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 477,

--- a/src/services/wetransfer.json
+++ b/src/services/wetransfer.json
@@ -1,5 +1,6 @@
 {
   "alexa": 283,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/whatpulse.json
+++ b/src/services/whatpulse.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 493,

--- a/src/services/whatsapp.json
+++ b/src/services/whatsapp.json
@@ -1,5 +1,6 @@
 {
   "alexa": 67,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 198,

--- a/src/services/wikia.json
+++ b/src/services/wikia.json
@@ -1,5 +1,6 @@
 {
   "alexa": 51,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 421,

--- a/src/services/wikia.json
+++ b/src/services/wikia.json
@@ -1,6 +1,8 @@
 {
   "alexa": 51,
-  "crawls": [],
+  "crawls": [
+    "wikia.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 421,

--- a/src/services/wikihow.json
+++ b/src/services/wikihow.json
@@ -1,5 +1,6 @@
 {
   "alexa": 200,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 315,

--- a/src/services/wikihow.json
+++ b/src/services/wikihow.json
@@ -1,6 +1,8 @@
 {
   "alexa": 200,
-  "crawls": [],
+  "crawls": [
+    "wikihow.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 315,

--- a/src/services/wikimedia.json
+++ b/src/services/wikimedia.json
@@ -1,5 +1,6 @@
 {
   "alexa": 268,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 177,

--- a/src/services/wikipedia.json
+++ b/src/services/wikipedia.json
@@ -1,5 +1,6 @@
 {
   "alexa": 5,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/wikipedia.json
+++ b/src/services/wikipedia.json
@@ -1,6 +1,9 @@
 {
   "alexa": 5,
-  "crawls": [],
+  "crawls": [
+    "wikipedia.org/Privacy Policy.txt",
+    "wikipedia.org/Terms of Use.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "privacy": {

--- a/src/services/windows-live.json
+++ b/src/services/windows-live.json
@@ -1,6 +1,9 @@
 {
   "alexa": 15,
-  "crawls": [],
+  "crawls": [
+    "live.com/Microsoft Services Agreement.txt",
+    "live.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 321,

--- a/src/services/windows-live.json
+++ b/src/services/windows-live.json
@@ -1,5 +1,6 @@
 {
   "alexa": 15,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 321,

--- a/src/services/wix.json
+++ b/src/services/wix.json
@@ -1,6 +1,8 @@
 {
   "alexa": 481,
-  "crawls": [],
+  "crawls": [
+    "wix.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/wix.json
+++ b/src/services/wix.json
@@ -1,5 +1,6 @@
 {
   "alexa": 481,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/wordfeud.json
+++ b/src/services/wordfeud.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 294,

--- a/src/services/wordpress-com.json
+++ b/src/services/wordpress-com.json
@@ -1,6 +1,10 @@
 {
   "alexa": 56,
-  "crawls": [],
+  "crawls": [
+    "wordpress.com/Privacy Policy.txt",
+    "wordpress.com/Terms Of Service.txt",
+    "wordpress.com/WordPress.com Terms Of Service.txt"
+  ],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/wordpress-com.json
+++ b/src/services/wordpress-com.json
@@ -1,5 +1,6 @@
 {
   "alexa": 56,
+  "crawls": [],
   "date": "",
   "freesoftware": false,
   "fulltos": {

--- a/src/services/world-of-warcraft.json
+++ b/src/services/world-of-warcraft.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1334,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 397,

--- a/src/services/world-of-warcraft.json
+++ b/src/services/world-of-warcraft.json
@@ -1,6 +1,8 @@
 {
   "alexa": 1334,
-  "crawls": [],
+  "crawls": [
+    "worldofwarcraft.com/World Of Warcraft Terms Of Use Agreement.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 397,

--- a/src/services/worldofwarcraft.json
+++ b/src/services/worldofwarcraft.json
@@ -1,6 +1,8 @@
 {
   "alexa": 1334,
-  "crawls": [],
+  "crawls": [
+    "worldofwarcraft.com/World Of Warcraft Terms Of Use Agreement.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 257,

--- a/src/services/worldofwarcraft.json
+++ b/src/services/worldofwarcraft.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1334,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 257,

--- a/src/services/writerduet.json
+++ b/src/services/writerduet.json
@@ -1,5 +1,6 @@
 {
   "alexa": 70932,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/xapo.json
+++ b/src/services/xapo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 482,

--- a/src/services/xfinity.json
+++ b/src/services/xfinity.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 489,

--- a/src/services/xfire.json
+++ b/src/services/xfire.json
@@ -1,5 +1,6 @@
 {
   "alexa": 709045,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 343,

--- a/src/services/xiaomi.json
+++ b/src/services/xiaomi.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 406,

--- a/src/services/xing.json
+++ b/src/services/xing.json
@@ -1,6 +1,9 @@
 {
   "alexa": 1811,
-  "crawls": [],
+  "crawls": [
+    "xing.com/Privacy Policy.txt",
+    "xing.com/Terms and Conditions.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 241,

--- a/src/services/xing.json
+++ b/src/services/xing.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1811,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 241,

--- a/src/services/yahoo.json
+++ b/src/services/yahoo.json
@@ -1,6 +1,9 @@
 {
   "alexa": 7,
-  "crawls": [],
+  "crawls": [
+    "yahoo.com/Privacy Policy.txt",
+    "yahoo.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 309,

--- a/src/services/yahoo.json
+++ b/src/services/yahoo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 7,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 309,

--- a/src/services/yammer.json
+++ b/src/services/yammer.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 353,

--- a/src/services/yelp.json
+++ b/src/services/yelp.json
@@ -1,6 +1,9 @@
 {
   "alexa": 221,
-  "crawls": [],
+  "crawls": [
+    "yelp.com/Privacy Policy.txt",
+    "yelp.com/Terms of Service.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 461,

--- a/src/services/yelp.json
+++ b/src/services/yelp.json
@@ -1,5 +1,6 @@
 {
   "alexa": 221,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 461,

--- a/src/services/yfrog.json
+++ b/src/services/yfrog.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 388,

--- a/src/services/yfrog.json
+++ b/src/services/yfrog.json
@@ -1,6 +1,8 @@
 {
   "alexa": 1000000,
-  "crawls": [],
+  "crawls": [
+    "yfrog.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 388,

--- a/src/services/yourepeat.json
+++ b/src/services/yourepeat.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 393,

--- a/src/services/youropinion.json
+++ b/src/services/youropinion.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 386,

--- a/src/services/youtube.json
+++ b/src/services/youtube.json
@@ -1,6 +1,9 @@
 {
   "alexa": 2,
-  "crawls": [],
+  "crawls": [
+    "youtube.com/Community Guidelines.txt",
+    "youtube.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 274,

--- a/src/services/youtube.json
+++ b/src/services/youtube.json
@@ -1,5 +1,6 @@
 {
   "alexa": 2,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 274,

--- a/src/services/yummly.json
+++ b/src/services/yummly.json
@@ -1,5 +1,6 @@
 {
   "alexa": 8240,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {
     "terms": {

--- a/src/services/zenfolio.json
+++ b/src/services/zenfolio.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 481,

--- a/src/services/zillow.json
+++ b/src/services/zillow.json
@@ -1,6 +1,8 @@
 {
   "alexa": 305,
-  "crawls": [],
+  "crawls": [
+    "zillow.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 323,

--- a/src/services/zillow.json
+++ b/src/services/zillow.json
@@ -1,5 +1,6 @@
 {
   "alexa": 305,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 323,

--- a/src/services/zoominfo.json
+++ b/src/services/zoominfo.json
@@ -1,5 +1,6 @@
 {
   "alexa": 1000000,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 500,

--- a/src/services/zooniverse.json
+++ b/src/services/zooniverse.json
@@ -1,5 +1,6 @@
 {
   "alexa": 149923,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 281,

--- a/src/services/zoosk.json
+++ b/src/services/zoosk.json
@@ -1,6 +1,8 @@
 {
   "alexa": 5080,
-  "crawls": [],
+  "crawls": [
+    "zoosk.com/Privacy Policy.txt"
+  ],
   "freesoftware": false,
   "fulltos": {},
   "id": 266,

--- a/src/services/zoosk.json
+++ b/src/services/zoosk.json
@@ -1,5 +1,6 @@
 {
   "alexa": 5080,
+  "crawls": [],
   "freesoftware": false,
   "fulltos": {},
   "id": 266,


### PR DESCRIPTION
For instance `500px.com/Privacy Policy.txt` can be found here: https://github.com/tosdr/tosback2/blob/master/crawl/500px.com/Privacy%20Policy.txt

This only adds relevant crawls if tosback2 is checked out next to tosdr-build, and removing them is not (yet) implemented.

Next step would be to use these crawls for point source.